### PR TITLE
Add schema config to switch using HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Insert this inside your `config/services.php`,
     'passkey' => 'your-password',
     'subdomain' => '',
     'masking' => false,
-    'schema' => 'https',
+    'scheme' => 'https',
 ],
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Insert this inside your `config/services.php`,
     'passkey' => 'your-password',
     'subdomain' => '',
     'masking' => false,
+    'schema' => 'https',
 ],
 ```
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,14 +9,14 @@ class Client
     const TIMEOUT = 60;
     const TYPE_REGULER = 'reguler';
     const TYPE_MASKING = 'masking';
-    const SCHEMA = 'https';
+    const SCHEME = 'https';
 
     /**
      * Zenziva end point
      *
      * @var string
      */
-    protected $url = '{schema}://{subdomain}.zenziva.net/apps/smsapi.php';
+    protected $url = '{scheme}://{subdomain}.zenziva.net/apps/smsapi.php';
 
     /**
      * Zenziva username
@@ -54,11 +54,11 @@ class Client
     public $subdomain = 'reguler';
     
     /**
-     * URL schema
+     * URL scheme
      *
      * @var string
      */
-    public $schema = 'https';
+    public $scheme = 'https';
 
     /**
      * SMS type. Masking or reguler.
@@ -156,15 +156,15 @@ class Client
     }
     
     /**
-     * Set URL schema
+     * Set URL scheme
      *
-     * @param $schema  Schema
+     * @param $scheme  scheme
      *
      * @return self
      */
-    public function schema($schema)
+    public function scheme($scheme)
     {
-        $this->schema = $schema == 'http' ? 'http' : self::SCHEMA;
+        $this->scheme = $scheme == 'http' ? 'http' : self::SCHEME;
 
         return $this;
     }
@@ -223,7 +223,7 @@ class Client
         }
 
         $url = str_replace('{subdomain}', $this->subdomain, $this->url);
-        $url = str_replace('{schema}', $this->schema, $url);
+        $url = str_replace('{scheme}', $this->scheme, $url);
 
         $params = http_build_query([
             'userkey' => $this->username,

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,13 +9,14 @@ class Client
     const TIMEOUT = 60;
     const TYPE_REGULER = 'reguler';
     const TYPE_MASKING = 'masking';
+    const SCHEMA = 'https';
 
     /**
      * Zenziva end point
      *
      * @var string
      */
-    protected $url = 'https://{subdomain}.zenziva.net/apps/smsapi.php';
+    protected $url = '{schema}://{subdomain}.zenziva.net/apps/smsapi.php';
 
     /**
      * Zenziva username
@@ -51,6 +52,13 @@ class Client
      * @var string
      */
     public $subdomain = 'reguler';
+    
+    /**
+     * URL schema
+     *
+     * @var string
+     */
+    public $schema = 'https';
 
     /**
      * SMS type. Masking or reguler.
@@ -78,7 +86,9 @@ class Client
      */
     public function url($url = '')
     {
-        if (!$url) return $this->url;
+        if (!$url) {
+            return $this->url;
+        }
 
         $this->url = $url;
 
@@ -144,6 +154,20 @@ class Client
 
         return $this;
     }
+    
+    /**
+     * Set URL schema
+     *
+     * @param $schema  Schema
+     *
+     * @return self
+     */
+    public function schema($schema)
+    {
+        $this->schema = $schema == 'http' ? 'http' : self::SCHEMA;
+
+        return $this;
+    }
 
     /**
      * @param $to  Phone number
@@ -199,6 +223,7 @@ class Client
         }
 
         $url = str_replace('{subdomain}', $this->subdomain, $this->url);
+        $url = str_replace('{schema}', $this->schema, $url);
 
         $params = http_build_query([
             'userkey' => $this->username,

--- a/src/NotificationChannel.php
+++ b/src/NotificationChannel.php
@@ -35,7 +35,7 @@ class NotificationChannel
     public function send(Collection $notifiables, Notification $notification)
     {
         foreach ($notifiables as $notifiable) {
-            if ( ! $to = $notifiable->routeNotificationFor('zenziva-sms')) {
+            if (! $to = $notifiable->routeNotificationFor('zenziva-sms')) {
                 continue;
             }
 

--- a/src/NotificationServiceProvider.php
+++ b/src/NotificationServiceProvider.php
@@ -28,8 +28,8 @@ class NotificationServiceProvider extends ServiceProvider
                 $sms->masking();
             }
             
-            if (in_array(config('services.zenziva.schema'), ['http', 'https'])) {
-                $sms->schema(config('services.zenziva.schema'));
+            if (in_array(config('services.zenziva.scheme'), ['http', 'https'])) {
+                $sms->scheme(config('services.zenziva.scheme'));
             }
 
             return $sms;

--- a/src/NotificationServiceProvider.php
+++ b/src/NotificationServiceProvider.php
@@ -27,6 +27,10 @@ class NotificationServiceProvider extends ServiceProvider
             if (config('services.zenziva.masking')) {
                 $sms->masking();
             }
+            
+            if (in_array(config('services.zenziva.schema'), ['http', 'https'])) {
+                $sms->schema(config('services.zenziva.schema'));
+            }
 
             return $sms;
         });

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -43,9 +43,9 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $case($sms);
     }
 
-     /**
-     * @return array
-     */
+    /**
+    * @return array
+    */
     public function sendCalls()
     {
         return [
@@ -75,7 +75,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
             ],
             [
                 function (Sms $sms) {
-                     $sms->expects($this->once())
+                    $sms->expects($this->once())
                         ->method('text')
                         ->will($this->returnSelf());
 
@@ -204,5 +204,53 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $sms->masking()->text('Hello')->to('085225575999')->send();
         $sms->subdomain('app')->masking()->send('085225575999', 'Hello');
         $sms->subdomain('app')->masking()->text('Hello')->to('085225575999')->send();
+    }
+    
+    public function test_buildQuery_method_should_works_properly_using_custom_schema()
+    {
+        $sms = $this->getMockBuilder(SMS::class)
+            ->setConstructorArgs(['john', 'password'])
+            ->setMethods(null)
+            ->getMock();
+
+        $sms->schema('http')->text('')->to('085225577999');
+
+        $reflection = new \ReflectionClass(get_class($sms));
+        $buildQueryMethod = $reflection->getMethod('buildQuery');
+        $buildQueryMethod->setAccessible(true);
+
+        $this->assertEquals('http://reguler.zenziva.net/apps/smsapi.php?userkey=john&passkey=password&tipe=reguler&nohp=085225577999&pesan=', $buildQueryMethod->invoke($sms));
+    }
+    
+    public function test_buildQuery_method_should_works_properly_using_custom_schema_and_subdomain()
+    {
+        $sms = $this->getMockBuilder(SMS::class)
+            ->setConstructorArgs(['john', 'password'])
+            ->setMethods(null)
+            ->getMock();
+
+        $sms->schema('http')->subdomain('matriphe')->text('')->to('085225577999');
+
+        $reflection = new \ReflectionClass(get_class($sms));
+        $buildQueryMethod = $reflection->getMethod('buildQuery');
+        $buildQueryMethod->setAccessible(true);
+
+        $this->assertEquals('http://matriphe.zenziva.net/apps/smsapi.php?userkey=john&passkey=password&tipe=reguler&nohp=085225577999&pesan=', $buildQueryMethod->invoke($sms));
+    }
+    
+    public function test_buildQuery_method_should_fallback_to_https_on_wron_schema()
+    {
+        $sms = $this->getMockBuilder(SMS::class)
+            ->setConstructorArgs(['john', 'password'])
+            ->setMethods(null)
+            ->getMock();
+
+        $sms->schema('ftp')->text('')->to('085225577999');
+
+        $reflection = new \ReflectionClass(get_class($sms));
+        $buildQueryMethod = $reflection->getMethod('buildQuery');
+        $buildQueryMethod->setAccessible(true);
+
+        $this->assertEquals('https://reguler.zenziva.net/apps/smsapi.php?userkey=john&passkey=password&tipe=reguler&nohp=085225577999&pesan=', $buildQueryMethod->invoke($sms));
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -206,14 +206,14 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $sms->subdomain('app')->masking()->text('Hello')->to('085225575999')->send();
     }
     
-    public function test_buildQuery_method_should_works_properly_using_custom_schema()
+    public function test_buildQuery_method_should_works_properly_using_custom_scheme()
     {
         $sms = $this->getMockBuilder(SMS::class)
             ->setConstructorArgs(['john', 'password'])
             ->setMethods(null)
             ->getMock();
 
-        $sms->schema('http')->text('')->to('085225577999');
+        $sms->scheme('http')->text('')->to('085225577999');
 
         $reflection = new \ReflectionClass(get_class($sms));
         $buildQueryMethod = $reflection->getMethod('buildQuery');
@@ -222,14 +222,14 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://reguler.zenziva.net/apps/smsapi.php?userkey=john&passkey=password&tipe=reguler&nohp=085225577999&pesan=', $buildQueryMethod->invoke($sms));
     }
     
-    public function test_buildQuery_method_should_works_properly_using_custom_schema_and_subdomain()
+    public function test_buildQuery_method_should_works_properly_using_custom_scheme_and_subdomain()
     {
         $sms = $this->getMockBuilder(SMS::class)
             ->setConstructorArgs(['john', 'password'])
             ->setMethods(null)
             ->getMock();
 
-        $sms->schema('http')->subdomain('matriphe')->text('')->to('085225577999');
+        $sms->scheme('http')->subdomain('matriphe')->text('')->to('085225577999');
 
         $reflection = new \ReflectionClass(get_class($sms));
         $buildQueryMethod = $reflection->getMethod('buildQuery');
@@ -238,14 +238,14 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://matriphe.zenziva.net/apps/smsapi.php?userkey=john&passkey=password&tipe=reguler&nohp=085225577999&pesan=', $buildQueryMethod->invoke($sms));
     }
     
-    public function test_buildQuery_method_should_fallback_to_https_on_wron_schema()
+    public function test_buildQuery_method_should_fallback_to_https_on_wron_scheme()
     {
         $sms = $this->getMockBuilder(SMS::class)
             ->setConstructorArgs(['john', 'password'])
             ->setMethods(null)
             ->getMock();
 
-        $sms->schema('ftp')->text('')->to('085225577999');
+        $sms->scheme('ftp')->text('')->to('085225577999');
 
         $reflection = new \ReflectionClass(get_class($sms));
         $buildQueryMethod = $reflection->getMethod('buildQuery');

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -206,7 +206,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $sms->subdomain('app')->masking()->text('Hello')->to('085225575999')->send();
     }
     
-    public function test_buildQuery_method_should_works_properly_using_custom_scheme()
+    public function test_buildQuery_method_should_works_properly_using_http_scheme()
     {
         $sms = $this->getMockBuilder(SMS::class)
             ->setConstructorArgs(['john', 'password'])
@@ -222,7 +222,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://reguler.zenziva.net/apps/smsapi.php?userkey=john&passkey=password&tipe=reguler&nohp=085225577999&pesan=', $buildQueryMethod->invoke($sms));
     }
     
-    public function test_buildQuery_method_should_works_properly_using_custom_scheme_and_subdomain()
+    public function test_buildQuery_method_should_works_properly_using_http_scheme_and_subdomain()
     {
         $sms = $this->getMockBuilder(SMS::class)
             ->setConstructorArgs(['john', 'password'])
@@ -238,7 +238,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://matriphe.zenziva.net/apps/smsapi.php?userkey=john&passkey=password&tipe=reguler&nohp=085225577999&pesan=', $buildQueryMethod->invoke($sms));
     }
     
-    public function test_buildQuery_method_should_fallback_to_https_on_wron_scheme()
+    public function test_buildQuery_method_should_fallback_to_https_on_wrong_scheme()
     {
         $sms = $this->getMockBuilder(SMS::class)
             ->setConstructorArgs(['john', 'password'])


### PR DESCRIPTION
Because in SMS Gateway API, HTTPS is add-on service, we need to use basic HTTP schema in API.

By adding method `schema($schema)` the API will use proper schema.